### PR TITLE
Stop forcing synchronous layouts while dragging

### DIFF
--- a/source/sortable-item-handle.js
+++ b/source/sortable-item-handle.js
@@ -202,6 +202,8 @@
             }
 
             itemPosition = $helper.positionStarted(eventObj, scope.itemScope.element, scrollableContainer);
+            $helper.movePosition(eventObj, dragElement, itemPosition, containment, containerPositioning, scrollableContainer);
+
             //fill the immediate vacuum.
             if (!scope.itemScope.sortableScope.options.clone) {
               scope.itemScope.element.after(placeHolder);
@@ -220,7 +222,6 @@
             }
 
             containment.append(dragElement);
-            $helper.movePosition(eventObj, dragElement, itemPosition, containment, containerPositioning, scrollableContainer);
 
             scope.sortableScope.$apply(function () {
               scope.callbacks.dragStart(dragItemInfo.eventArgs());
@@ -319,16 +320,15 @@
                 });
               }
 
-              $helper.movePosition(eventObj, dragElement, itemPosition, containment, containerPositioning, scrollableContainer);
-
               targetX = eventObj.pageX - $document[0].documentElement.scrollLeft;
               targetY = eventObj.pageY - ($window.pageYOffset || $document[0].documentElement.scrollTop);
 
               //IE fixes: hide show element, call element from point twice to return pick correct element.
-              dragElement.addClass(sortableConfig.hiddenClass);
-              $document[0].elementFromPoint(targetX, targetY);
               targetElement = angular.element($document[0].elementFromPoint(targetX, targetY));
+              dragElement.addClass(sortableConfig.hiddenClass);
               dragElement.removeClass(sortableConfig.hiddenClass);
+
+              $helper.movePosition(eventObj, dragElement, itemPosition, containment, containerPositioning, scrollableContainer);
 
               //Set Class as dragging starts
               dragElement.addClass(sortableConfig.dragging);


### PR DESCRIPTION
Currently, there are a lot of forced synchronous layouts while dragging a card:

![screen shot 2015-12-18 at 11 15 08 am](https://cloud.githubusercontent.com/assets/443084/11903753/9bd07dde-a578-11e5-8675-89c223a9500a.png)

This is a [significant performance bottleneck](https://developers.google.com/web/tools/chrome-devtools/profile/rendering-tools/analyze-runtime#how-to-identify-layout-bottlenecks), especially in mobile browsers. The way to fix that is to group all your DOM reads together before doing any DOM writes. Simply rearranging these few lines, we were able to remove all of the forced synchronous layouts and we saw a noticeable performance boost even in Chrome. Should be even more noticeable in other browsers.

For reference, prior to this change, every `mousemove` event was taking 11.20ms:

![screen shot 2015-12-18 at 11 36 00 am](https://cloud.githubusercontent.com/assets/443084/11904179/9815cc46-a57b-11e5-86ac-cccee9b15c22.png)

After this change, it was down to 4.30ms (~60% performance boost):

![screen shot 2015-12-18 at 11 32 50 am](https://cloud.githubusercontent.com/assets/443084/11904191/a57506c2-a57b-11e5-990d-f05eb0cc909c.png)

That might seem trivial, but it is actually very significant given that it is happening on every single `mousemove` event as you drag an item.
